### PR TITLE
Impurities

### DIFF
--- a/src/LegendGeSim.jl
+++ b/src/LegendGeSim.jl
@@ -56,6 +56,7 @@ const μs_unit = u"μs"
 const germanium_ionization_energy = SolidStateDetectors.material_properties[:HPGe].E_ionisation # in eV
 
 include("sim_config.jl")
+include("impurity_models.jl")
 include("pss.jl")
 include("legend_detector_to_ssd.jl")
 include("detector.jl")

--- a/src/detector.jl
+++ b/src/detector.jl
@@ -104,6 +104,22 @@ function siggen_config(meta::PropDict, env::Environment, siggen_sim::SiggenSimul
     fieldgen_lines = readlines(open(joinpath(dirname(@__DIR__), "examples", "configs", "fieldgen_settings.txt")))
     fieldgen_lines = replace.(fieldgen_lines, "\t" => "   ")
 
+    # Impurities from Legend metadata:
+    begin
+        mjd_imp_pars = LegendGeSim.determine_MJDFieldGenImpurityParameter_from_metadata(Float64, meta)
+        iline = findfirst(l -> startswith(l, "impurity_z0"), fieldgen_lines) 
+        fieldgen_lines[iline] = "impurity_z0         $(mjd_imp_pars.impurity_z0)   # net impurity concentration at Z=0, in 1e10 e/cm3"
+        iline = findfirst(l -> startswith(l, "impurity_gradient"), fieldgen_lines) 
+        fieldgen_lines[iline] = "impurity_gradient         $(mjd_imp_pars.impurity_gradient)   # net impurity concentration at Z=0, in 1e10 e/cm3"
+        iline = findfirst(l -> startswith(l, "impurity_quadratic"), fieldgen_lines) 
+        fieldgen_lines[iline] = "impurity_quadratic         $(mjd_imp_pars.impurity_quadratic)   # net impurity concentration at Z=0, in 1e10 e/cm3"
+        # ToDo: add also those... for now only z-profile
+        # impurity_surface = T(0),
+        # impurity_radial_add = T(0),
+        # impurity_radial_mult = T(1),
+        # impurity_rpower = T(0)
+    end
+    
     # unite constructed detector geometry and fieldgen settings
     total_lines = vcat(detector_lines, [""], fieldgen_lines)
 

--- a/src/impurity_models.jl
+++ b/src/impurity_models.jl
@@ -78,7 +78,18 @@ function SolidStateDetectors.get_impurity_density(
 end
 
 
+"""
+    get_impurity_density_poly_from_metadata(::Type{T}, imp_dict::PropDict) where {T}
 
+This function extracts an polynomial for the impurity density along z
+from the legend metadata configuration file. 
+
+If there is a offset (and/or direction change) between the 
+in the metadata file defined impurity density profile of the CRYSTAL (not detector)
+and the coordinate system of the detector, this has to be taken into account in this function.
+
+The returned polynomial should be in detector coordinates!
+"""
 function get_impurity_density_poly_from_metadata(::Type{T}, imp_dict::PropDict) where {T}
     zs_from_contact = T.(imp_dict.array.dist_from_contact_in_mm) # in mm
     imp_levels_at_z = T.(imp_dict.array[Symbol("value_in_1e9e/cm3")] ./ 10)  # in T(1e10) * u"cm^-3"
@@ -86,6 +97,9 @@ function get_impurity_density_poly_from_metadata(::Type{T}, imp_dict::PropDict) 
     if detector_is_p_type
         imp_levels_at_z *= -1
     end
+
+    # zs in mm
+    # imp values (return value of the polynomial) in 1e10/cm3
     return Polynomials.fit(zs_from_contact, imp_levels_at_z)
 end
 
@@ -104,7 +118,7 @@ function determine_MJDFieldGenImpurityParameter_from_metadata(::Type{T}, detecto
     # for the z component
     impurity_z0 = imp_level_at_0
     impurity_quadratic = length(sub_poly.coeffs) == 3 ? (-sub_poly.coeffs[3] * H^2) : 0
-    impurity_gradient = (((length(sub_poly.coeffs[2]) >= 2) ? sub_poly.coeffs[2] : 0) - 2*impurity_quadratic/H) * 10  # *10 since unit conversion inv(cm^3 * mm)
+    impurity_gradient = (((length(sub_poly.coeffs) >= 2) ? sub_poly.coeffs[2] : 0) - 2*impurity_quadratic/H) * 10  # *10 since unit conversion inv(cm^3 * mm)
 
     return (;
         impurity_z0,

--- a/src/impurity_models.jl
+++ b/src/impurity_models.jl
@@ -1,0 +1,143 @@
+"""
+    struct MJDFieldGenImpurityModel{T} <: SolidStateDetectors.AbstractImpurityDensity{T}
+
+Impurity density for SolidStateDetectors for comparison to MJDFieldGen.
+The definition and parameterization is based on the source code of MJDFieldGen.
+
+In SSD, SI units are used. 
+"""
+struct MJDFieldGenImpurityModel{T} <: SolidStateDetectors.AbstractImpurityDensity{T}
+    xtal_radius::T # radius of the detector
+    xtal_length_half::T # half length (in z) of the detector
+    # float impurity_z0;          // net impurity concentration at Z=0, in 1e10 e/cm3
+    impurity_z0::T
+    # float impurity_gradient;    // net impurity gradient, in 1e10 e/cm4
+    impurity_gradient::T
+    # float impurity_quadratic;   // net impurity difference from linear, at z=L/2, in 1e10 e/cm3
+    impurity_quadratic::T
+    # float impurity_surface;     // surface impurity of passivation layer, in 1e10 e/cm2
+    # impurity_surface::T # This is handled in SSD via fix space charge density and not impurity densities
+    # float impurity_radial_add;  // additive radial impurity at outside radius, in 1e10 e/cm3
+    impurity_radial_add::T
+    # float impurity_radial_mult; // multiplicative radial impurity at outside radius (neutral=1.0)
+    impurity_radial_mult::T
+    # float impurity_rpower;      // power for radial impurity increase with radius
+    impurity_rpower::T
+end
+
+function MJDFieldGenImpurityModel{T}(s::SigGenSetup) where {T}
+    if s.impurity_surface != 0
+        @warn """FieldGen impurity density has a surface charge.
+        This is handled in SSD via static charge densities and not the impurity density.
+        Make sure this is correctly passed to SSD.
+        """
+    end
+    MJDFieldGenImpurityModel{T}(
+        ustrip(uconvert(u"m", (s.xtal_radius) * u"mm")), 
+        ustrip(uconvert(u"m", (s.xtal_length/2) * u"mm")), 
+        ustrip(uconvert(u"m^(-3)", s.impurity_z0 * u"1e10*cm^(-3)")),        
+        ustrip(uconvert(u"m^(-4)", s.impurity_gradient * u"1e10*cm^(-4)")),  
+        ustrip(uconvert(u"m^(-3)", s.impurity_quadratic * u"1e10*cm^(-3)")),  
+        ustrip(uconvert(u"m^(-3)", s.impurity_radial_add * u"1e10*cm^(-3)")), 
+        s.impurity_radial_mult,
+        s.impurity_rpower,            
+    )
+end
+
+function SolidStateDetectors.get_impurity_density(
+    cdm::MJDFieldGenImpurityModel{T},
+    pt::SolidStateDetectors.AbstractCoordinatePoint{T}
+) where {T}
+    cyl = CylindricalPoint(pt)
+    r, z = cyl[1], cyl[3] 
+    # From FieldGen Source code `mjd_fieldgen.c`:
+    ρ_z = begin # z component
+        # imp_z[i] = e_over_E * grid*grid / 4.0 *
+        # (setup->impurity_z0 +
+        #  setup->impurity_gradient * z * 0.1 +
+        #  setup->impurity_quadratic *
+        #  (1.0 - SQ(z - setup->xtal_length/2.0) / SQ(setup->xtal_length/2.0)));
+        # }
+        # #define SQ(x) ((x)*(x))
+        cdm.impurity_z0 + 
+        cdm.impurity_gradient * z + 
+        cdm.impurity_quadratic * (T(1) - (z - cdm.xtal_length_half)^2 / cdm.xtal_length_half^2);
+    end
+    ρ_r_m = begin # radial mult. component
+        # imp_rm = 1.0 + (setup->impurity_radial_mult - 1.0f) *
+        #     pow((double) r / setup->xtal_radius, setup->impurity_rpower);
+        1 + (cdm.impurity_radial_mult - 1) * (r / cdm.xtal_radius)^cdm.impurity_rpower
+    end
+    ρ_r_a = begin # radial additive component
+        # imp_ra = setup->impurity_radial_add * e_over_E * grid*grid / 4.0 *
+        #     pow((double) r / setup->xtal_radius, setup->impurity_rpower);
+        cdm.impurity_radial_add * (r / cdm.xtal_radius)^cdm.impurity_rpower
+    end
+    # imp_z[i] * imp_rm + imp_ra;
+    return ρ_z * ρ_r_m + ρ_r_a
+end
+
+
+
+function get_impurity_density_poly_from_metadata(::Type{T}, imp_dict::PropDict) where {T}
+    zs_from_contact = T.(imp_dict.array.dist_from_contact_in_mm) # in mm
+    imp_levels_at_z = T.(imp_dict.array[Symbol("value_in_1e9e/cm3")] ./ 10)  # in T(1e10) * u"cm^-3"
+    return Polynomials.fit(zs_from_contact, imp_levels_at_z)
+end
+
+function determine_MJDFieldGenImpurityParameter_from_metadata(::Type{T}, detector_metadata::PropDict) where {T}
+    imp_poly = get_impurity_density_poly_from_metadata(T, detector_metadata.production.impcc) # returns in 1e10/cm3
+    R = T(detector_metadata.geometry.radius_in_mm) 
+    L = T(detector_metadata.geometry.height_in_mm) 
+    H = T(L/2)
+    imp_level_at_0 = imp_poly(T(0))
+    imp_level_at_H = imp_poly(H)
+    imp_level_at_L = imp_poly(L)
+    sub_poly = Polynomials.fit(T[0, H, L], T[imp_level_at_0, imp_level_at_H, imp_level_at_L])
+
+    # the following parameters are determined by solving the equations of  
+    # SolidStateDetectors.get_impurity_density(cdm::MJDFieldGenImpurityModel{T}, pt::SolidStateDetectors.AbstractCoordinatePoint{T})
+    # for the z component
+    impurity_z0 = imp_level_at_0
+    impurity_quadratic = -sub_poly.coeffs[3] * H^2
+    impurity_gradient = (sub_poly.coeffs[2] - 2*impurity_quadratic/H) * 10  # *10 since unit conversion inv(cm^3 * mm)
+
+    return (;
+        impurity_z0,
+        impurity_gradient,
+        impurity_quadratic,
+        impurity_surface = T(0),
+        impurity_radial_add = T(0),
+        impurity_radial_mult = T(1),
+        impurity_rpower = T(0)
+    )
+end
+
+function MJDFieldGenImpurityModel{T}(
+    mjd_imp_par::NamedTuple{(:impurity_z0, 
+                             :impurity_gradient, 
+                             :impurity_quadratic, 
+                             :impurity_surface, 
+                             :impurity_radial_add, 
+                             :impurity_radial_mult, 
+                             :impurity_rpower)},
+    detector_length, # in mm
+    detector_radius  # in mm
+    ) where {T}
+    if mjd_imp_par.impurity_surface != 0
+        @warn """FieldGen impurity density has a surface charge.
+        This is handled in SSD via static charge densities and not the impurity density.
+        Make sure this is correctly passed to SSD.
+        """
+    end
+    MJDFieldGenImpurityModel{T}(
+        ustrip(uconvert(u"m", detector_radius * u"mm")), 
+        ustrip(uconvert(u"m", (detector_length/2) * u"mm")), 
+        ustrip(uconvert(u"m^(-3)", mjd_imp_par.impurity_z0 * u"1e10*cm^(-3)")),        
+        ustrip(uconvert(u"m^(-4)", mjd_imp_par.impurity_gradient * u"1e10*cm^(-4)")),  
+        ustrip(uconvert(u"m^(-3)", mjd_imp_par.impurity_quadratic * u"1e10*cm^(-3)")),  
+        ustrip(uconvert(u"m^(-3)", mjd_imp_par.impurity_radial_add * u"1e10*cm^(-3)")), 
+        mjd_imp_par.impurity_radial_mult,
+        mjd_imp_par.impurity_rpower,            
+    )
+end

--- a/src/impurity_models.jl
+++ b/src/impurity_models.jl
@@ -103,8 +103,8 @@ function determine_MJDFieldGenImpurityParameter_from_metadata(::Type{T}, detecto
     # SolidStateDetectors.get_impurity_density(cdm::MJDFieldGenImpurityModel{T}, pt::SolidStateDetectors.AbstractCoordinatePoint{T})
     # for the z component
     impurity_z0 = imp_level_at_0
-    impurity_quadratic = -sub_poly.coeffs[3] * H^2
-    impurity_gradient = (sub_poly.coeffs[2] - 2*impurity_quadratic/H) * 10  # *10 since unit conversion inv(cm^3 * mm)
+    impurity_quadratic = length(sub_poly.coeffs) == 3 ? (-sub_poly.coeffs[3] * H^2) : 0
+    impurity_gradient = (((length(sub_poly.coeffs[2]) >= 2) ? sub_poly.coeffs[2] : 0) - 2*impurity_quadratic/H) * 10  # *10 since unit conversion inv(cm^3 * mm)
 
     return (;
         impurity_z0,

--- a/src/impurity_models.jl
+++ b/src/impurity_models.jl
@@ -82,6 +82,10 @@ end
 function get_impurity_density_poly_from_metadata(::Type{T}, imp_dict::PropDict) where {T}
     zs_from_contact = T.(imp_dict.array.dist_from_contact_in_mm) # in mm
     imp_levels_at_z = T.(imp_dict.array[Symbol("value_in_1e9e/cm3")] ./ 10)  # in T(1e10) * u"cm^-3"
+    detector_is_p_type = true # should be defined in the config files? Assume this for now
+    if detector_is_p_type
+        imp_levels_at_z *= -1
+    end
     return Polynomials.fit(zs_from_contact, imp_levels_at_z)
 end
 

--- a/src/mjdsiggen_utils.jl
+++ b/src/mjdsiggen_utils.jl
@@ -1,8 +1,7 @@
-function SolidStateDetectors.ElectricPotential(sim::SigGenSetup)
+function SolidStateDetectors.ElectricPotential(sim::SigGenSetup, ::Type{T} = Float32) where {T}
     E_pot, W_pot, E_abs, E_r, E_z = LegendGeSim.MJDSigGen.read_fields(sim);
-    T = eltype(E_pot)
-    r_axis = (0:(sim.rlen - 1)) * sim.xtal_grid
-    z_axis = (0:(sim.zlen - 1)) * sim.xtal_grid
+    r_axis = (0:(sim.rlen - 1)) * sim.xtal_grid / 1000 # SSD is in SI Units: m
+    z_axis = (0:(sim.zlen - 1)) * sim.xtal_grid / 1000 # SSD is in SI Units: m
     ax1 = SolidStateDetectors.DiscreteAxis{T, :r0, :fixed, ClosedInterval{T}}(r_axis[1]..r_axis[end], r_axis)
     ax2 = SolidStateDetectors.DiscreteAxis{T, :reflecting, :reflecting, ClosedInterval{T}}(zero(T)..zero(T), zeros(T, 1))
     ax3 = SolidStateDetectors.DiscreteAxis{T, :reflecting, :reflecting, ClosedInterval{T}}(z_axis[1]..z_axis[end], z_axis)
@@ -13,11 +12,10 @@ function SolidStateDetectors.ElectricPotential(sim::SigGenSetup)
     ElectricPotential(data, grid)
 end
 
-function SolidStateDetectors.WeightingPotential(sim::SigGenSetup)
+function SolidStateDetectors.WeightingPotential(sim::SigGenSetup, ::Type{T} = Float32) where {T}
     E_pot, W_pot, E_abs, E_r, E_z = LegendGeSim.MJDSigGen.read_fields(sim);
-    T = eltype(W_pot)
-    r_axis = (0:(sim.rlen - 1)) * sim.xtal_grid
-    z_axis = (0:(sim.zlen - 1)) * sim.xtal_grid
+    r_axis = (0:(sim.rlen - 1)) * sim.xtal_grid / 1000 # SSD is in SI Units: m
+    z_axis = (0:(sim.zlen - 1)) * sim.xtal_grid / 1000 # SSD is in SI Units: m
     ax1 = SolidStateDetectors.DiscreteAxis{T, :r0, :fixed, ClosedInterval{T}}(r_axis[1]..r_axis[end], r_axis)
     ax2 = SolidStateDetectors.DiscreteAxis{T, :reflecting, :reflecting, ClosedInterval{T}}(zero(T)..zero(T), zeros(T, 1))
     ax3 = SolidStateDetectors.DiscreteAxis{T, :reflecting, :reflecting, ClosedInterval{T}}(z_axis[1]..z_axis[end], z_axis)


### PR DESCRIPTION
I looked into the source code of MJDFieldGen and figured out how the impurity density is parameterized.

I created a function to extract the values for the parameters from legend metadata files via
the impurity levels at different z: `determine_MJDFieldGenImpurityParameter_from_metadata`

These parameters are now put into the configuration text file for FieldGen.

I also created a struct for it to be used for SSD: 
`struct MJDFieldGenImpurityModel{T} <: SolidStateDetectors.AbstractImpurityDensity{T}`
It can be constructed from the NamedTuple returned from `determine_MJDFieldGenImpurityParameter_from_metadata`
or from a `::SigGenSetup` object from MJDSigGen.jl.

The model also have some radial modulation. Which is implemented for `MJDFieldGenImpurityModel` in principle.
But there is no read-in as there are no information in the metadata files. So there is no radial modulation.

`MJDFieldGenImpurityModel` does not have a field for `impurity_surface` as surface charges are
handled differently in SSD.