### PR TITLE
Update IO to new LEGEND metadata format

### DIFF
--- a/src/legend_detector_to_ssd.jl
+++ b/src/legend_detector_to_ssd.jl
@@ -58,7 +58,7 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
             Δr = hZ * tan(top_outer_taper_angle)         
             r_in_bot = r_center + Δr
             r_in_top = r_center - Δr
-            r_out = crystal_radius + gap
+            r_out = max(r_in_top, r_in_bot) + gap # ensure that r_out is always bigger as r_in
             r = ((r_in_bot, r_out),(r_in_top, r_out))
             semiconductor_geometry -= CSG.Cone{T}(CSG.ClosedPrimitive; 
                 r = r,
@@ -115,7 +115,7 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
             Δr = hZ * tan(bot_outer_taper_angle)         
             r_in_bot = r_center - Δr
             r_in_top = r_center + Δr
-            r_out = crystal_radius + gap
+            r_out = max(r_in_top, r_in_bot) + gap # ensure that r_out is always bigger as r_in
             r = ((r_in_bot, r_out),(r_in_top, r_out))
             semiconductor_geometry -= CSG.Cone{T}(CSG.ClosedPrimitive; 
                 r = r,

--- a/src/legend_detector_to_ssd.jl
+++ b/src/legend_detector_to_ssd.jl
@@ -84,16 +84,15 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
         end
         if has_top_inner_taper
             r_center = borehole_radius + top_inner_taper_height * tan(top_inner_taper_angle) / 2
-            hZ = top_inner_taper_height/2 + 1gap
+            hZ = top_inner_taper_height/2
             Δr = hZ * tan(top_inner_taper_angle)         
             r_out_bot = r_center - Δr
-            r_out_top = r_center + Δr
-            r_in = zero(T)
-            r = ((r_in, r_out_bot),(r_in, r_out_top))
+	    r_out_top = r_center + Δr * (1 + 2*gap/hZ)
+	    r = ((r_out_bot,), (r_out_top,))
             semiconductor_geometry -= CSG.Cone{T}(CSG.ClosedPrimitive; 
                 r = r,
-                hZ = hZ, 
-                origin = CartesianPoint{T}(0, 0, crystal_height - top_inner_taper_height/2)
+                hZ = hZ + gap, 
+                origin = CartesianPoint{T}(0, 0, crystal_height - top_inner_taper_height/2 + gap)
             )
         end
 


### PR DESCRIPTION
There were some format changes to the metadata files in https://github.com/legend-exp/legend-detectors/pull/5/
which cause the current version of LegendGeSim.jl to throw errors when reading files in the new format.

I updated the IO of LEGEND metadata files by incorporating the following changes:
* `det_name` renamed to `name`
* `op_voltage_in_V` renamed to `recommended_voltage_in_V`
* `well` renamed to `borehole`
* `crack`, `topgroove`, `bottom cylinder` moved to `extra` => warning that extras are not implemented yet

@sagitta42 : could you check if this update works for you?