### PR TITLE
Update IO to new LEGEND metadata format

### DIFF
--- a/src/legend_detector_to_ssd.jl
+++ b/src/legend_detector_to_ssd.jl
@@ -3,6 +3,7 @@
 to_SSD_units(::Type{T}, x, unit) where {T} = T(SolidStateDetectors.to_internal_units(x*unit)) 
 
 function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
+    
         # Not all possible configurations are yet implemented!
         # https://github.com/legend-exp/legend-metadata/blob/main/hardware/detectors/detector-metadata_1.pdf
         # https://github.com/legend-exp/legend-metadata/blob/main/hardware/detectors/detector-metadata_2.pdf
@@ -19,6 +20,8 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
 
         crystal_radius = to_SSD_units(T, meta.geometry.radius_in_mm, u"mm")
         crystal_height = to_SSD_units(T, meta.geometry.height_in_mm, u"mm")
+        
+        is_coax = meta.type == "coax"
 
         # main crystal
         semiconductor_geometry = CSG.Cone{T}(CSG.ClosedPrimitive; 
@@ -29,89 +32,99 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
             
         # borehole
         has_borehole = haskey(meta.geometry, :borehole)
+        if is_coax && !has_borehole
+            error("Coax detectors should have boreholes")
+        end
         if has_borehole
-            borehole_well = to_SSD_units(T, meta.geometry.borehole.gap_in_mm, u"mm")
-            borehole_height = crystal_height - borehole_well
+            borehole_depth = to_SSD_units(T, meta.geometry.borehole.depth_in_mm, u"mm")
             borehole_radius = to_SSD_units(T, meta.geometry.borehole.radius_in_mm, u"mm")
             semiconductor_geometry -= CSG.Cone{T}(CSG.ClosedPrimitive; 
                 r = borehole_radius, 
-                hZ = borehole_height / 2 + gap, 
-                origin = CartesianPoint{T}(0, 0, borehole_well + borehole_height/2 + gap)
-            )
+                hZ = borehole_depth / 2 + gap, 
+                origin = CartesianPoint{T}(0, 0, is_coax ? borehole_depth/2 - gap : crystal_height - borehole_depth/2 + gap)
+            )    
+        end
+        
+        # borehole taper
+        has_borehole_taper = haskey(meta.geometry.taper, :borehole)
+        if has_borehole_taper
+            borehole_taper_height = to_SSD_units(T, meta.geometry.taper.borehole.height_in_mm, u"mm")
+            if haskey(meta.geometry.taper.borehole, :radius_in_mm)
+                borehole_taper_radius = to_SSD_units(T, meta.geometry.taper.borehole.radius_in_mm, u"mm")
+                borehole_taper_angle = atan(borehole_taper_radius, borehole_taper_height)
+            elseif haskey(meta.geometry.taper.borehole, :angle_in_deg)
+                borehole_taper_angle = to_SSD_units(T, meta.geometry.taper.borehole.angle_in_deg, u"°")
+                borehole_taper_radius = borehole_taper_height * tan(borehole_taper_angle)
+            else
+                error("The borehole taper needs either radius_in_mm or angle_in_deg")
+            end
+            has_borehole_taper = borehole_taper_height > 0 && borehole_taper_angle > 0
+            if has_borehole_taper && !has_borehole 
+                error("A detector without a borehole cannot have a borehole taper.")
+            end
+            if has_borehole_taper && is_coax
+                error("Coax detectors should not have borehole tapers")
+            end
+            if has_borehole_taper
+                r_center = borehole_radius + borehole_taper_height * tan(borehole_taper_angle) / 2
+                hZ = borehole_taper_height/2
+                Δr = hZ * tan(borehole_taper_angle)         
+                r_out_bot = r_center - Δr
+            r_out_top = r_center + Δr * (1 + 2*gap/hZ)
+            r = ((r_out_bot,), (r_out_top,))
+                semiconductor_geometry -= CSG.Cone{T}(CSG.ClosedPrimitive; 
+                    r = r,
+                    hZ = hZ + gap, 
+                    origin = CartesianPoint{T}(0, 0, crystal_height - borehole_taper_height/2 + gap)
+                )
+            end
         end
 
-        # top outer taper
-        top_outer_taper_height = to_SSD_units(T, meta.geometry.taper.top.outer.height_in_mm, u"mm")
-        if :radius_in_mm in keys(meta.geometry.taper.top.outer)
-            top_outer_taper_radius = to_SSD_units(T, meta.geometry.taper.top.outer.radius_in_mm, u"mm")
-            top_outer_taper_angle = atan(top_outer_taper_radius, top_outer_taper_height)
-        elseif :angle_in_deg in keys(meta.geometry.taper.top.outer)
-            top_outer_taper_angle = to_SSD_units(T, meta.geometry.taper.top.outer.angle_in_deg, u"°")
-            top_outer_taper_radius = top_outer_taper_height * tan(top_outer_taper_angle)
-        else
-            error("The top outer taper needs either radius_in_mm or angle_in_deg")
-        end
-        has_top_outer_taper = top_outer_taper_height > 0 && top_outer_taper_angle > 0
-        if has_top_outer_taper
-            r_center = crystal_radius - top_outer_taper_height * tan(top_outer_taper_angle) / 2
-            hZ = top_outer_taper_height/2 + 1gap
-            Δr = hZ * tan(top_outer_taper_angle)         
-            r_in_bot = r_center + Δr
-            r_in_top = r_center - Δr
-            r_out = max(r_in_top, r_in_bot) + gap # ensure that r_out is always bigger as r_in
-            r = ((r_in_bot, r_out),(r_in_top, r_out))
-            semiconductor_geometry -= CSG.Cone{T}(CSG.ClosedPrimitive; 
-                r = r,
-                hZ = hZ, 
-                origin = CartesianPoint{T}(0, 0, crystal_height - top_outer_taper_height/2)
-            )
-        end
-
-        # top inner taper
-        top_inner_taper_height = to_SSD_units(T, meta.geometry.taper.top.inner.height_in_mm, u"mm")
-        if :radius_in_mm in keys(meta.geometry.taper.top.inner)
-            top_inner_taper_radius = to_SSD_units(T, meta.geometry.taper.top.inner.radius_in_mm, u"mm")
-            top_inner_taper_angle = atan(top_inner_taper_radius, top_inner_taper_height)
-        elseif :angle_in_deg in keys(meta.geometry.taper.top.inner)
-            top_inner_taper_angle = to_SSD_units(T, meta.geometry.taper.top.inner.angle_in_deg, u"°")
-            top_inner_taper_radius = top_inner_taper_height * tan(top_inner_taper_angle)
-        else
-            error("The top inner taper needs either radius_in_mm or angle_in_deg")
-        end
-        has_top_inner_taper = top_inner_taper_height > 0 && top_inner_taper_angle > 0
-        if has_top_inner_taper && !has_borehole 
-            error("A detector without a borehole cannot have a top inner taper.")
-        end
-        if has_top_inner_taper
-            r_center = borehole_radius + top_inner_taper_height * tan(top_inner_taper_angle) / 2
-            hZ = top_inner_taper_height/2
-            Δr = hZ * tan(top_inner_taper_angle)         
-            r_out_bot = r_center - Δr
-	    r_out_top = r_center + Δr * (1 + 2*gap/hZ)
-	    r = ((r_out_bot,), (r_out_top,))
-            semiconductor_geometry -= CSG.Cone{T}(CSG.ClosedPrimitive; 
-                r = r,
-                hZ = hZ + gap, 
-                origin = CartesianPoint{T}(0, 0, crystal_height - top_inner_taper_height/2 + gap)
-            )
+        # top taper
+        if haskey(meta.geometry.taper, :top)
+            top_taper_height = to_SSD_units(T, meta.geometry.taper.top.height_in_mm, u"mm")
+            if haskey(meta.geometry.taper.top, :radius_in_mm)
+                top_taper_radius = to_SSD_units(T, meta.geometry.taper.top.radius_in_mm, u"mm")
+                top_taper_angle = atan(top_taper_radius, top_taper_height)
+            elseif haskey(meta.geometry.taper.top, :angle_in_deg)
+                top_taper_angle = to_SSD_units(T, meta.geometry.taper.top.angle_in_deg, u"°")
+                top_taper_radius = top_taper_height * tan(top_taper_angle)
+            else
+                error("The top taper needs either radius_in_mm or angle_in_deg")
+            end
+            has_top_taper = top_taper_height > 0 && top_taper_angle > 0
+            if has_top_taper
+                r_center = crystal_radius - top_taper_height * tan(top_taper_angle) / 2
+                hZ = top_taper_height/2 + 1gap
+                Δr = hZ * tan(top_taper_angle)         
+                r_in_bot = r_center + Δr
+                r_in_top = r_center - Δr
+                r_out = max(r_in_top, r_in_bot) + gap # ensure that r_out is always bigger as r_in
+                r = ((r_in_bot, r_out),(r_in_top, r_out))
+                semiconductor_geometry -= CSG.Cone{T}(CSG.ClosedPrimitive; 
+                    r = r,
+                    hZ = hZ, 
+                    origin = CartesianPoint{T}(0, 0, crystal_height - top_taper_height/2)
+                )
+            end
         end
 
         # bot outer taper
-        bot_outer_taper_height = to_SSD_units(T, meta.geometry.taper.bottom.outer.height_in_mm, u"mm")
-        if :radius_in_mm in keys(meta.geometry.taper.bottom.outer)
-            bot_outer_taper_radius = to_SSD_units(T, meta.geometry.taper.bottom.outer.radius_in_mm, u"mm")
-            bot_outer_taper_angle = atan(bot_outer_taper_radius, bot_outer_taper_height)
-        elseif :angle_in_deg in keys(meta.geometry.taper.bottom.outer)
-            bot_outer_taper_angle = to_SSD_units(T, meta.geometry.taper.bottom.outer.angle_in_deg, u"°")
-            bot_outer_taper_radius = bot_outer_taper_height * tan(bot_outer_taper_angle)
+        bot_taper_height = to_SSD_units(T, meta.geometry.taper.bottom.height_in_mm, u"mm")
+        if :radius_in_mm in keys(meta.geometry.taper.bottom)
+            bot_taper_radius = to_SSD_units(T, meta.geometry.taper.bottom.radius_in_mm, u"mm")
+            bot_taper_angle = atan(bot_taper_radius, bot_taper_height)
+        elseif :angle_in_deg in keys(meta.geometry.taper.bottom)
+            bot_taper_angle = to_SSD_units(T, meta.geometry.taper.bottom.angle_in_deg, u"°")
+            bot_taper_radius = bot_taper_height * tan(bot_taper_angle)
         else
             error("The bottom outer tape needs either radius_in_mm or angle_in_deg")
         end
-        has_bot_outer_taper = bot_outer_taper_height > 0 && bot_outer_taper_angle > 0
-        if has_bot_outer_taper
-            r_center = crystal_radius - bot_outer_taper_height * tan(bot_outer_taper_angle) / 2
-            hZ = bot_outer_taper_height/2 + 1gap
-            Δr = hZ * tan(bot_outer_taper_angle)         
+        has_bot_taper = bot_taper_height > 0 && bot_taper_angle > 0
+        if has_bot_taper
+            r_center = crystal_radius - bot_taper_height * tan(bot_taper_angle) / 2
+            hZ = bot_taper_height/2 + 1gap
+            Δr = hZ * tan(bot_taper_angle)         
             r_in_bot = r_center - Δr
             r_in_top = r_center + Δr
             r_out = max(r_in_top, r_in_bot) + gap # ensure that r_out is always bigger as r_in
@@ -119,45 +132,61 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
             semiconductor_geometry -= CSG.Cone{T}(CSG.ClosedPrimitive; 
                 r = r,
                 hZ = hZ, 
-                origin = CartesianPoint{T}(0, 0, bot_outer_taper_height/2)
+                origin = CartesianPoint{T}(0, 0, bot_taper_height/2)
             )
         end
 
         # groove
-        groove_outer_radius = to_SSD_units(T, meta.geometry.groove.outer_radius_in_mm, u"mm")
-        groove_depth = to_SSD_units(T, meta.geometry.groove.depth_in_mm, u"mm")
-        groove_width = to_SSD_units(T, meta.geometry.groove.width_in_mm, u"mm")
-        has_groove = groove_outer_radius > 0 && groove_depth > 0 && groove_width > 0
+        has_groove = haskey(meta.geometry, :groove)
         if has_groove
-            hZ = groove_depth/2 + 1
-            r_in = groove_outer_radius - groove_width
-            r_out = groove_outer_radius
-            r = ((r_in, r_out), (r_in, r_out))
-            semiconductor_geometry -= CSG.Cone{T}(CSG.ClosedPrimitive; 
-                r = r, 
-                hZ = groove_depth / 2 + gap, 
-                origin = CartesianPoint{T}(0, 0, groove_depth/2 - gap)
-            )
+            groove_inner_radius = to_SSD_units(T, meta.geometry.groove.radius_in_mm.inner, u"mm")
+            groove_outer_radius = to_SSD_units(T, meta.geometry.groove.radius_in_mm.outer, u"mm")
+            groove_depth = to_SSD_units(T, meta.geometry.groove.depth_in_mm, u"mm")
+            has_groove = groove_outer_radius > 0 && groove_depth > 0 && groove_inner_radius > 0
+            if has_groove
+                hZ = groove_depth / 2 + gap
+                r_in = groove_inner_radius
+                r_out = groove_outer_radius
+                r = ((r_in, r_out), (r_in, r_out))
+                semiconductor_geometry -= CSG.Cone{T}(CSG.ClosedPrimitive; 
+                    r = r, 
+                    hZ = hZ,
+                    origin = CartesianPoint{T}(0, 0, groove_depth / 2 - gap)
+                )
+            end
         end
-
+        
+        
         # bulletization
-        is_bulletized = !all(values(meta.geometry.bulletization) .== 0)
-        is_bulletized && @warn "Bulletization is not implemented yet, ignore for now."
+        # is_bulletized = !all(values(meta.geometry.bulletization) .== 0)
+        # is_bulletized && @warn "Bulletization is not implemented yet, ignore for now."
 
         # extras
         haskey(meta.geometry, :extra) && @warn "Extras are not implemented yet, ignore for now."
 
 
-        ### POINT CONTACT ###
+        ### P+ CONTACT ###
 
-        point_contact_geometry = begin
-            pc_radius = to_SSD_units(T, meta.geometry.contact.radius_in_mm, u"mm")
-            pc_depth = to_SSD_units(T, meta.geometry.contact.depth_in_mm, u"mm")
-
+        pp_radius = to_SSD_units(T, meta.geometry.pp_contact.radius_in_mm, u"mm")
+        pp_depth = to_SSD_units(T, meta.geometry.pp_contact.depth_in_mm, u"mm")
+        pp_contact_geometry = if is_coax
+            CSG.Cone{T}(CSG.ClosedPrimitive;
+                r = ((borehole_radius, borehole_radius), (borehole_radius, borehole_radius)),
+                hZ = borehole_depth/2,
+                origin = CartesianPoint{T}(0, 0, borehole_depth / 2)
+            ) + CSG.Cone{T}(CSG.ClosedPrimitive;
+                r = borehole_radius,
+                hZ = 0,
+                origin = CartesianPoint{T}(0, 0, borehole_depth)
+            ) + CSG.Cone{T}(CSG.ClosedPrimitive;
+                r = ((borehole_radius, pp_radius), (borehole_radius, pp_radius)),
+                hZ = 0
+            )
+        else
             CSG.Cone{T}(CSG.ClosedPrimitive; 
-                r = pc_radius, 
-                hZ = pc_depth / 2, 
-                origin = CartesianPoint{T}(0, 0, pc_depth / 2)
+                r = pp_radius, 
+                hZ = pp_depth / 2, 
+                origin = CartesianPoint{T}(0, 0, pp_depth / 2)
             )
         end
 
@@ -166,13 +195,13 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
         
         mantle_contact_geometry = begin # top plate
             top_plate = begin
-                r = if !has_borehole 
-                    !has_top_outer_taper ? crystal_radius : crystal_radius - top_outer_taper_radius
-                else 
+                r = if !has_borehole || is_coax
+                    !has_top_taper ? crystal_radius : crystal_radius - top_taper_radius
+                else has_borehole && !is_coax
                     r_in = borehole_radius
                     r_out = crystal_radius
-                    if has_top_inner_taper r_in += top_inner_taper_radius end
-                    if has_top_outer_taper r_out -= top_outer_taper_radius end
+                    if has_borehole_taper r_in += borehole_taper_radius end
+                    if has_top_taper r_out -= top_taper_radius end
                     ((r_in, r_out), (r_in, r_out))
                 end
                 CSG.Cone{T}(CSG.ClosedPrimitive; 
@@ -184,41 +213,41 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
             mc_geometry = top_plate
             
             # borehole at outer taper
-            if has_top_outer_taper
-                Δr_li_thickness = li_thickness / cos(top_outer_taper_angle)
-                hZ = top_outer_taper_height/2
+            if has_top_taper
+                Δr_li_thickness = li_thickness / cos(top_taper_angle)
+                hZ = top_taper_height/2
                 r_bot = crystal_radius 
-                r_top = crystal_radius - top_outer_taper_radius
+                r_top = crystal_radius - top_taper_radius
                 r = ((r_bot - Δr_li_thickness, r_bot),(r_top - Δr_li_thickness, r_top))
                 mc_geometry += CSG.Cone{T}(CSG.ClosedPrimitive; 
                     r = r,
                     hZ = hZ, 
-                    origin = CartesianPoint{T}(0, 0, crystal_height - top_outer_taper_height/2)
+                    origin = CartesianPoint{T}(0, 0, crystal_height - top_taper_height/2)
                 )
             end
 
             # contact in borehole
-            if has_top_inner_taper
-                Δr_li_thickness = li_thickness / cos(top_inner_taper_angle)
-                hZ = top_inner_taper_height/2    
+            if has_borehole_taper
+                Δr_li_thickness = li_thickness / cos(borehole_taper_angle)
+                hZ = borehole_taper_height/2    
                 r_bot = borehole_radius
-                r_top = borehole_radius + top_inner_taper_radius
+                r_top = borehole_radius + borehole_taper_radius
                 r = ((r_bot, r_bot+Δr_li_thickness),(r_top, r_top+Δr_li_thickness))
                 mc_geometry += CSG.Cone{T}(CSG.ClosedPrimitive; 
                     r = r,
                     hZ = hZ, 
-                    origin = CartesianPoint{T}(0, 0, crystal_height - top_inner_taper_height/2)
+                    origin = CartesianPoint{T}(0, 0, crystal_height - borehole_taper_height/2)
                 )
 
-                hZ = (borehole_height - top_inner_taper_height) / 2
+                hZ = (borehole_depth - borehole_taper_height) / 2
                 r = ((borehole_radius, borehole_radius+Δr_li_thickness),(borehole_radius, borehole_radius+Δr_li_thickness))
                 mc_geometry += CSG.Cone{T}(CSG.ClosedPrimitive; 
                     r = r,
                     hZ = hZ, 
-                    origin = CartesianPoint{T}(0, 0, crystal_height - top_inner_taper_height - hZ)
+                    origin = CartesianPoint{T}(0, 0, crystal_height - borehole_taper_height - hZ)
                 )
-            elseif has_borehole # but no inner taper
-                hZ = borehole_height / 2
+            elseif has_borehole && !is_coax # but no borehole taper
+                hZ = borehole_depth / 2
                 r = ((borehole_radius, borehole_radius+li_thickness),(borehole_radius, borehole_radius+li_thickness))
                 mc_geometry += CSG.Cone{T}(CSG.ClosedPrimitive; 
                     r = r,
@@ -227,12 +256,12 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
                 )
             end
 
-            if has_borehole
+            if has_borehole && !is_coax
                 r = borehole_radius + li_thickness
                 mc_geometry += CSG.Cone{T}(CSG.ClosedPrimitive; 
                     r = r, 
                     hZ = li_thickness / 2, 
-                    origin = CartesianPoint{T}(0, 0, crystal_height - borehole_height - li_thickness / 2)
+                    origin = CartesianPoint{T}(0, 0, crystal_height - borehole_depth - li_thickness / 2)
                 )
             end
 
@@ -240,11 +269,11 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
             begin
                 r = ((crystal_radius-li_thickness, crystal_radius),(crystal_radius-li_thickness, crystal_radius))
                 hZ = crystal_height
-                if has_top_outer_taper hZ -= top_outer_taper_height end
+                if has_top_taper hZ -= top_taper_height end
                 z_origin = hZ/2
-                if has_bot_outer_taper 
-                    hZ -= bot_outer_taper_height 
-                    z_origin += bot_outer_taper_height/2
+                if has_bot_taper 
+                    hZ -= bot_taper_height 
+                    z_origin += bot_taper_height/2
                 end
                 mc_geometry += CSG.Cone{T}(CSG.ClosedPrimitive; 
                     r = r, 
@@ -254,10 +283,10 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
             end
 
             # bottom outer taper contact
-            if has_bot_outer_taper
-                Δr_li_thickness = li_thickness / cos(bot_outer_taper_angle)
-                hZ = bot_outer_taper_height/2
-                r_bot = crystal_radius - bot_outer_taper_radius
+            if has_bot_taper
+                Δr_li_thickness = li_thickness / cos(bot_taper_angle)
+                hZ = bot_taper_height/2
+                r_bot = crystal_radius - bot_taper_radius
                 r_top = crystal_radius
                 r = ((r_bot - Δr_li_thickness, r_bot),(r_top - Δr_li_thickness, r_top))
                 mc_geometry += CSG.Cone{T}(CSG.ClosedPrimitive; 
@@ -268,10 +297,10 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
             end  
 
             # bottom surface of mantle contact (only if it has a groove ?)
-            if groove_outer_radius > 0
+            if has_groove && groove_outer_radius > 0
                 r_in = groove_outer_radius 
                 r_out = crystal_radius
-                if has_bot_outer_taper r_out -= bot_outer_taper_radius end
+                if has_bot_taper r_out -= bot_taper_radius end
                 r = ((r_in, r_out), (r_in, r_out))
                 mc_geometry += CSG.Cone{T}(CSG.ClosedPrimitive; 
                     r = r, 
@@ -308,12 +337,12 @@ function LEGEND_SolidStateDetector(::Type{T}, meta::PropDict) where {T}
         semiconductor = SolidStateDetectors.Semiconductor(temperature, material, impurity_density_model, charge_drift_model, semiconductor_geometry)
 
         operation_voltage = T(meta.characterization.manufacturer.recommended_voltage_in_V)
-        point_contact = SolidStateDetectors.Contact( zero(T), material, 1, "Point Contact", point_contact_geometry )
+        pp_contact = SolidStateDetectors.Contact( zero(T), material, 1, "Point Contact", pp_contact_geometry )
         mantle_contact = SolidStateDetectors.Contact( operation_voltage, material, 2, "Mantle Contact", mantle_contact_geometry )
 
-        semiconductor, (point_contact, mantle_contact)
+        semiconductor, (pp_contact, mantle_contact)
 
         passives = missing # possible holding structure around the detector
         virtual_drift_volumes = missing
-        SolidStateDetector{T}( meta.name, semiconductor, [point_contact, mantle_contact], passives, virtual_drift_volumes )
+        SolidStateDetector{T}( meta.name, semiconductor, [pp_contact, mantle_contact], passives, virtual_drift_volumes )
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,23 +7,27 @@ using LegendGeSim
 using LegendTestData
 using Unitful
 
-testdata_path = joinpath(LegendTestData.legend_test_data_path(), "data", "ldsim")
+testdata_path = joinpath(LegendTestData.legend_test_data_path(), "data", "legend", "metadata", "hardware", "detectors", "germanium", "diodes")
+
+test_dict = Dict{String, typeof(1.0u"pF")}(
+    "B99000A.json" => -7.13u"pF",
+    "V99000A.json" => -3.55u"pF"
+)
 
 @testset "Package LegendGeSim" begin
-    detector_metadata_filename = joinpath(testdata_path, "invcoax-metadata.json") # path to my detector metadata
-    sim_settings_ssd_filename = joinpath(dirname(dirname(pathof(LegendGeSim))), "examples/configs/SSD_NoiseSim.json")
+    for (filename, capacitance) in test_dict
+        detector_metadata_filename = joinpath(testdata_path, filename)
+        sim_settings_ssd_filename = joinpath(dirname(dirname(pathof(LegendGeSim))), "examples/configs/SSD_NoiseSim.json")
+        
+        @testset "Field Simulation of $filename (SSD)" begin
+            config = LegendGeSim.load_config(detector_metadata_filename, sim_settings_ssd_filename);
+            sim = LegendGeSim.simulate_fields(config)
+            C = LegendGeSim.capacitance_matrix(sim)
 
-    
-    @testset "Field Simulation (SSD)" begin
-        config = LegendGeSim.load_config(detector_metadata_filename, sim_settings_ssd_filename);
-
-        sim = LegendGeSim.simulate_fields(config)
-
-        C = LegendGeSim.capacitance_matrix(sim)
-
-        @testset "Capacitances" begin   
-            @test isapprox(ustrip(C[1,2]), -3.25, atol = 0.2)
+            @testset "Capacitances" begin   
+                @test isapprox(C[1,2], capacitance, atol = 0.2u"pF")
+            end
         end
-    end
-end 
+    end 
+end
 


### PR DESCRIPTION
There were some more format changes to the metadata files 
which cause the current version of LegendGeSim.jl to throw errors when reading files in the new format.

I updated the IO of LEGEND metadata files by incorporating the following changes:

* Boreholes are defined with `height` instead of `gap`
* The `top.outer` taper was renamed to `top` taper
* The `top.inner` taper was renamed to `borehole` taper
* The `bottom.outer` taper was renamed to `bottom` taper
* The `contact` was renamed to `pp_contact`
* Boreholes of `icpc` detectors and `coax` detectors are parsed differently due to differences in geometry
* Contacts for `coax` are parsed differently due to differences in geometry

I again assume the tests to fail because we might also need to update the [legend-testdata](https://github.com/legend-exp/legend-testdata).