### PR TITLE
Update TrapFilter to use RadiationDetectorDSP

### DIFF
--- a/src/temp_utils.jl
+++ b/src/temp_utils.jl
@@ -40,8 +40,8 @@ Replace negative values by zeros.
 Used to remove a glitch in SSD pulses as a quick fix
     while the glitch is being debugged.
 """
-function remove_negative(value::Real)
-    value < 0 ? 0 : value
+function remove_negative(value::T)::T where {T <: Real}
+    max(zero(T), value)
 end
 
 

--- a/src/trigger.jl
+++ b/src/trigger.jl
@@ -67,35 +67,6 @@ end
 # -------------------------------------------------------------------
 
 """
-    trap_filter(wf_values, sample_idx, trap_filter)
-
-AbstractVector, Int, TrapFilter -> Real, Bool 
-
-Simulate the output of the trapezoidal filter algorithm
-    applied to <wf_values> when the first sliding window starts
-    at <sample_idx>.
-The trapezoidal algorithm parameters are contained in <trap_filter.
-The returned values are the online energy estimate corresponding to the
-    difference between the 1st and the 3rd sliding window, and a Bool
-    correspondong to whether there is a trigger issued or not.    
-"""
-function trap_filter(wf_values::AbstractVector, sample_idx::Int, trap_filter::TrapFilter)
-    # first window
-    r1 = sample_idx : sample_idx + trap_filter.window_lengths[1]
-    # third window
-    r2 = sample_idx + trap_filter.window_lengths[1] + trap_filter.window_lengths[2] : sample_idx + sum(trap_filter.window_lengths)
-    # difference between the third and first window
-    r = mean(wf_values[r2]) - mean(wf_values[r1])
-    r, r >= trap_filter.threshold
-end
-
-
-function trap_filter(wf::RDWaveform, sample_idx::Int, trigger::TrapFilter)
-    trap_filter(wf.signal, sample_idx, trigger)
-end
-
-
-"""
     simulate(wf, trap_filter)
 
 RDWaveform, TrapFilter -> Int, Real 

--- a/src/trigger.jl
+++ b/src/trigger.jl
@@ -79,12 +79,12 @@ function simulate(wf::RDWaveform, trigger::TrapFilter)
     T = Float32 # This should be somehow defined and be passed properly
     trigger_window_length = sum(trigger.window_lengths)
     
-    fi = fltinstance(TrapezoidalChargeFilter{T}(reverse(trigger.window_lengths)...), smplinfo(wf)) 
-    online_filter_output = similar(wf.signal, length(wf.signal) - trigger_window_length + 1)
+    fi = fltinstance(TrapezoidalChargeFilter{T}(reverse(trigger.window_lengths)...), smplinfo(wf.signal)) 
+    online_filter_output = Vector{T}(undef, length(wf.signal) - trigger_window_length + 1)
     rdfilt!(online_filter_output, fi, wf.signal)
     
     t0idx = findfirst(online_filter_output .>= trigger.threshold) + fi.ngap + fi.navg2 - 1
-    t0idx, T(maximum(online_filter_output))
+    t0idx, maximum(online_filter_output)
 end
 
 


### PR DESCRIPTION
I updated the function and it gives similar/same results.

I tested it using:

```julia
using LegendGeSim
using RadiationDetectorSignals
using RadiationDetectorDSP
using Unitful
using BenchmarkTools

# Create example TrapFilter
trigger = LegendGeSim.TrapFilter((40,10,100), 20u"keV", 0.008)
trigger_window_length = sum(trigger.window_lengths)

# Create example waveform
ts = (0:1:1000)
f(x) = Float64.(min(max(0, -2 + 0.005x), 1))
wf = RDWaveform(ts, f.(ts));
```
![image](https://github.com/legend-exp/LegendGeSim.jl/assets/30291312/04b05c65-cc70-4b3c-a9a8-b4b7673ccec7)


```julia
@btime LegendGeSim.simulate($wf, $trigger)
```
```
# output old implementation 
  226.763 μs (5107 allocations: 1.12 MiB)
(319, 0.4f0)

# output new implementation
  4.320 μs (8 allocations: 11.31 KiB)
(319, 0.4f0)
```


It also looks like the waveforms after applying the trap filter using the old and new method look more or less identical
```julia
using Plots

# Create example TrapFilter
trigger = LegendGeSim.TrapFilter((40,10,100), 20u"keV", 0.008)
trigger_window_length = sum(trigger.window_lengths)

# Create example waveform
f(x) = Float64.(min(max(0, -2 + 0.005x), 1))
ts = (0:1:1000)
wf = RDWaveform(ts, f.(ts));

# Apply the TrapFilter to the waveform 
old = map(i -> LegendGeSim.trap_filter(wf, i, trigger)[1], eachindex(wf.signal[1:end-trigger_window_length]))
fi = fltinstance(TrapezoidalChargeFilter{Float32}(reverse(trigger.window_lengths)...), smplinfo(wf)) 
new = similar(wf.signal, length(wf.signal) - trigger_window_length + 1)
rdfilt!(new, fi, wf.signal)

plot(wf, label = "Test waveform")
plot!(old, label = "LegendGeSim - old")
plot!(new, label = "LegendGeSim - new")
```

![image](https://github.com/legend-exp/LegendGeSim.jl/assets/30291312/674b1d0c-5719-4186-9d52-e21ad070ba38)

