### PR TITLE
Add tests: `pet -> raw` simulation chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 Manifest.toml
 examples/cache
 examples/undepleted.txt
+test/cache

--- a/src/temp_utils.jl
+++ b/src/temp_utils.jl
@@ -18,13 +18,11 @@ filename(path) = splitext(basename(path))[1]
 AbstractString -> PropDict 
 
 Construct a PropDict based on given <json_file>.
-
-1) Why can't I name it function PropDict()?
-2) Why doesn't this already exist in PropDicts?
-I find the PropDicts.read(PropDict, String) format kinda cumbersome
+Alias for `readprops` from PropDicts.jl
+    
 """
 function propdict(json_file::AbstractString)
-    PropDicts.read(PropDict, json_file)
+    readprops(json_file)
 end
 
     

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+LegendHDF5IO = "c9265ca6-b027-5446-b1a4-febfa8dd10b0"
 LegendTestData = "33d6da08-6349-5f7c-b5a4-6ff4d8795aaf"
-SolidStateDetectors = "71e43887-2bd9-5f77-aebd-47f656f0a3f0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,19 +2,25 @@
 
 using Test
 
-using SolidStateDetectors
 using LegendGeSim
+using LegendHDF5IO, HDF5
 using LegendTestData
 using Unitful
 
-testdata_path = joinpath(LegendTestData.legend_test_data_path(), "data", "legend", "metadata", "hardware", "detectors", "germanium", "diodes")
+# Temporary quick fix to compare RDWaveforms
+using LegendGeSim: RDWaveform
+Base.:(==)(wf::RDWaveform, nwf::RDWaveform) = 
+    reduce((x,field) -> x && isequal(getfield(wf, field), getfield(nwf, field)), fieldnames(RDWaveform), init = typeof(wf) == typeof(nwf))
 
-test_dict = Dict{String, typeof(1.0u"pF")}(
-    "B99000A.json" => -7.13u"pF",
-    "V99000A.json" => -3.55u"pF"
-)
 
-@testset "Package LegendGeSim" begin
+@testset "LegendGeSim: Simulate capacitances of test detectors" begin
+
+    testdata_path = joinpath(legend_test_data_path(), "data", "legend", "metadata", "hardware", "detectors", "germanium", "diodes")
+    test_dict = Dict{String, typeof(1.0u"pF")}(
+        "B99000A.json" => -7.13u"pF",
+        "V99000A.json" => -3.55u"pF"
+    )
+
     for (filename, capacitance) in test_dict
         detector_metadata_filename = joinpath(testdata_path, filename)
         sim_settings_ssd_filename = joinpath(dirname(dirname(pathof(LegendGeSim))), "examples/configs/detector_study_ssd.json")
@@ -30,3 +36,88 @@ test_dict = Dict{String, typeof(1.0u"pF")}(
     end 
 end
 
+
+@testset "LegendGeSim: sim -> raw simulation chain" begin
+
+    ldsim_path = joinpath(legend_test_data_path(), "data", "ldsim")
+    det_metadata = joinpath(ldsim_path, "invcoax-metadata.json")
+    path_to_pet_file = joinpath(ldsim_path, "single-invcoax-th228-geant4.csv")
+
+    environment_settings = Dict(
+        "crystal_temperature_in_K" => 77,
+        "medium" => "vacuum" 
+    )
+
+    simulation_settings = Dict(
+        "method" => "ssd",
+        "cached_name" => "test",
+    )
+    
+
+    pss_table, pss_truth = LegendGeSim.simulate_pulses(det_metadata, path_to_pet_file, environment_settings, simulation_settings) #; n_waveforms=10
+
+    @testset "pet -> pss" begin 
+        @test pss_table isa LegendGeSim.Table
+        @test pss_truth isa LegendGeSim.Table
+    end
+
+    setup_settings = Dict(
+        "preamp" => Dict(
+            "type" => "generic",
+            "t_decay" => 50,
+            "t_rise" => 15,
+            "max_e" => 10000,
+            "offset" => 2000
+        ),
+        "fadc" => Dict(
+            "type" => "generic",
+            "sampling_interval" => 16
+        ),
+        "trigger" => Dict(
+            "type" => "trapezoidal",        
+            "window_lengths" => [250,250,250],
+            "threshold" => 9
+        ),
+        "daq" => Dict(
+            "type" => "generic",
+            "nsamples" => 3750,
+            "baseline_length" => 1875
+        )
+    )
+
+    pss_name = "cache/" * LegendGeSim.filename(path_to_pet_file) * "_pss.hdf5"
+    h5open(pss_name, "w") do f
+        LegendHDF5IO.writedata(f, "pss/pss", pss_table)
+        LegendHDF5IO.writedata(f, "pss/truth", pss_truth)
+    end
+
+    @testset "pss I/O using LegendHDF5IO" begin
+        @test isfile(pss_name)
+        h = LHDataStore(pss_name)
+        @test haskey(h, "pss")
+        close(h)
+    end
+
+    raw_table = LegendGeSim.pss_to_raw(pss_name, setup_settings)
+
+    @testset "pss -> raw" begin
+        @test raw_table isa LegendGeSim.Table
+        @test length(raw_table) == 240
+    end
+
+    # Skip writing the pss to disk and check that the result is still the same
+    all_settings = Dict(
+        "environment" => environment_settings,
+        "simulation" => simulation_settings,
+        "setup" => setup_settings
+    )
+
+    new_raw_table = LegendGeSim.simulate_raw(det_metadata, path_to_pet_file, all_settings; n_waveforms=5)
+
+    @testset "pet -> raw" begin
+        @test new_raw_table[1:5] == raw_table[1:5]
+    end
+
+    # Delete the cached files
+    rm("cache", force=true, recursive=true)
+end


### PR DESCRIPTION
I slightly modified the `pet -> raw` simulation chain I was given by @sagitta42 to act as a test script.

Disclaimer: the tests will fail now because [LegendTestData.jl](https://github.com/legend-exp/LegendTestData.jl) still links to an old commit of [legend-test-data](https://github.com/legend-exp/legend-testdata) where `invcoax-metadata.json` is still in the old metadata format. Once LegendTestData.jl is updated, these tests should pass.
I would ask @oschulz to please take care of this.

Running the tests, the function `propdict` threw a deprecation warning. I updated it to use the PropDicts `readprops` function. We could think about getting rid of `propdict` in LegendGeSim.jl and replace all `propdict` by `readprops`.
Any thoughts about this?