### PR TITLE
gain instead of Emax, ADC options and more

### DIFF
--- a/src/baselines.jl
+++ b/src/baselines.jl
@@ -11,9 +11,12 @@ function extend_baseline(baseline::RDWaveform, wf::RDWaveform)
     baseline_sampled = baseline.signal[begin:Int(step(wf.time)/step(baseline.time)):end]
 
     ## create extended/shrinked baseline
+    ## ToDo: find actual no-signal baselines (possible in HADES data?..) and properly slap
+    # accounting for chirp noises etc., this is sort of NoiseHybrid...
     # offset
     values = ones(length(wf.signal)).*mean(baseline_sampled)
     # noise
+    T = Float32 # quickfix ToDo make normal T flow
     gaussian_noise_dist = Normal(T(0), T(std(baseline_sampled)))
     values = values .+ rand!(gaussian_noise_dist, similar(values))
 
@@ -91,10 +94,17 @@ end
 
 function selection_cut(wf::RDWaveform, base_uplim::Real, base_lolim::Real)
     # baseline start cut
-    base_start = wf.signal[1]
-    peak_index = risepoint(wf)
+    base_start = wf.signal[1] # value of waveform at the beginning
+    peak_index = risepoint(wf) # value of wf right before signal rising i.e. end of baseline
     baseline = wf.signal[begin:peak_index]
+    # is this supposed to remove pileup? i think it is base_slope() due to it not being flat
     cut_base::Bool = (base_start < base_uplim) && (base_start > base_lolim) && (base_start - mean(baseline) < 50)
+
+    # already return false if this one cut is false 
+    # otherwise there are bugs in base_slope()
+    if !cut_base
+        return false
+    end
 
     # wveform value cut 
     cut_value = wf.signal[1000] > 1000
@@ -102,6 +112,12 @@ function selection_cut(wf::RDWaveform, base_uplim::Real, base_lolim::Real)
     # peak cut 
     peak = findmax(wf.signal)[2]
     cut_peak = peak < 2100 && peak > 1650
+
+    # already return false if this one cut is false 
+    # otherwise there are bugs in base_slope()
+    if !cut_peak
+        return false
+    end
 
     # slope cut 
     slope_t1 = tail_slope(wf, trunc(Int, (length(wf.signal)-peak)*0.5))
@@ -112,7 +128,8 @@ function selection_cut(wf::RDWaveform, base_uplim::Real, base_lolim::Real)
     slope_b  = base_slope(wf, 100)
     cut_bslope = slope_b < 0.001 && slope_b > -0.001
 
-    cut_base && cut_value && cut_peak && cut_slope && cut_bslope
+    # cut_base && cut_value && cut_peak && cut_slope && cut_bslope
+    cut_value && cut_slope && cut_bslope
 end
 
 
@@ -141,6 +158,7 @@ end
 function base_slope(wf::RDWaveform, n)
     #slope of the tail  n = 1800
     utime, ucharge = _fast_ustrip(wf.time), _fast_ustrip(wf.signal)
+    # this assumes the waveform has a flat baseline and then signal peak i.e. pileup has to be removed before this cut
     peak = findmax(ucharge)[2]
     signalstats(RDWaveform(utime, ucharge), first(utime), utime[peak-n]).slope
 end

--- a/src/detector.jl
+++ b/src/detector.jl
@@ -42,6 +42,11 @@ Look up fieldgen generated electric field and weighting potential files
 function simulate_detector(det_meta::PropDict, env::Environment, simulator::SiggenSimulator;
         overwrite::Bool = false)
 
+    # if no cached name given, force simulation from scratch (or else might read past "tmp" file)
+    if simulator.cached_name == ""
+        overwrite = true
+    end
+
     # returns the name of the resulting siggen config file
     # and the name of (already or to be) generated weighting potential file
     # ToDo: don't create if already present already at this stage -> check in siggen_config() if name exists and just return name

--- a/src/fadc.jl
+++ b/src/fadc.jl
@@ -81,7 +81,7 @@ function simulate(wf::RDWaveform, fadc::GenericFADC)
     wf_daq = RDWaveform(t_sampled, wf_sampled)
 
     # digitize
-    wf_daq = RDWaveform(wf_daq.time, UInt16.(round.(wf_daq.signal, digits = 0)))
-
+    # wf_daq = RDWaveform(wf_daq.time, UInt16.(round.(wf_daq.signal, digits = 0)))
+    wf_daq = RDWaveform( wf_daq.time, UInt16.(clamp.(round.(wf_daq.signal, digits = 0), 0, typemax(UInt16))) )
     wf_daq
 end

--- a/src/legend_detector_to_siggen.jl
+++ b/src/legend_detector_to_siggen.jl
@@ -19,14 +19,14 @@ function siggen_config(meta::PropDict, env::Environment, simulator::SiggenSimula
 
     # if no cached name was given by user, make a temporaty name - needed for fieldgen to read from file
     # also if no cached name was given means definitely doing from scratch
+    cached_name = simulator.cached_name
     if simulator.cached_name == ""
-        simulator.cached_name = "tmp"
+        cached_name = "tmp"
         overwrite = true
     end
 
-    # cached_name = simulator.cached_name == "" ? "tmp" : simulator.cached_name    
     # append detector name
-    cached_name = meta.name * "_" * simulator.cached_name  
+    cached_name = meta.name * "_" * cached_name  
     
     # filenames for fieldgen input/output 
     # ! no need to add cache/ folder because siggen does it by itself...

--- a/src/noise.jl
+++ b/src/noise.jl
@@ -154,8 +154,8 @@ function simulate_noise(wf::RDWaveform, preamp::PreAmp)
     # wf values are in eV (without u"eV" units attached), noise sigma is in keV
     # if we're not simulating noise from scratch, we'll do this anyway, but noise sigma will be 0
     # -> maybe there's a better way?
-    noise_σ = preamp.noise_σ_keV == 0 ? preamp.noise_σ_ADC / preamp.gain : uconvert(u"eV", preamp.noise_σ_keV)
-    noise_σ = ustrip(noise_σ)
+    noise_σ = preamp.noise_σ_keV == 0u"keV" ? preamp.noise_σ_ADC / preamp.gain : uconvert(u"eV", preamp.noise_σ_keV)
+    noise_σ = ustrip(u"eV", noise_σ)
     gaussian_noise_dist = Normal(T(0), T(noise_σ))
     RDWaveform(wf.time, wf.signal .+ rand!(gaussian_noise_dist, similar(wf.signal)))
 end

--- a/src/noise.jl
+++ b/src/noise.jl
@@ -92,6 +92,7 @@ function NoiseModel(noise_settings::PropDict)
     else
         NoiseFromData(noise_settings)
     end
+    # ToDo add elseif and error if not none, sim or data
 end
 # function NoiseModel(sim_config::LegendGeSimConfig)
     # if haskey(sim_config.dict, :noise_data)
@@ -113,7 +114,7 @@ Calculate fano noise level based on the detector specification provided in
     and add it to given <events>
 """
 function fano_noise(events::Table, det_meta::PropDict, env::Environment, ::NoiseFromSim)
-    @info "//\\//\\//\\ Fano noise"
+    @info "//\\//\\//\\ Adding fano noise"
     # println("Adding fano noise")
     detector = LEGEND_SolidStateDetector(Float32, det_meta, env)
     # ssd_conf = ssd_config(det_meta, env)
@@ -137,7 +138,7 @@ function fano_noise(events::Table, ::PropDict, ::Environment, ::NoiseFromData)
 end
 
 function fano_noise(events::Table, ::PropDict, ::Environment, ::NoiseNone)
-    println("No fano noise (ideal simulation)")
+    println("No fano noise (no noise model given)")
     events
 end
 
@@ -153,7 +154,8 @@ function simulate_noise(wf::RDWaveform, preamp::PreAmp)
     # wf values are in eV (without u"eV" units attached), noise sigma is in keV
     # if we're not simulating noise from scratch, we'll do this anyway, but noise sigma will be 0
     # -> maybe there's a better way?
-    noise_σ = ustrip(uconvert(u"eV", preamp.noise_σ))
+    noise_σ = preamp.noise_σ_keV == 0 ? preamp.noise_σ_ADC / preamp.gain : uconvert(u"eV", preamp.noise_σ_keV)
+    noise_σ = ustrip(noise_σ)
     gaussian_noise_dist = Normal(T(0), T(noise_σ))
     RDWaveform(wf.time, wf.signal .+ rand!(gaussian_noise_dist, similar(wf.signal)))
 end

--- a/src/pss.jl
+++ b/src/pss.jl
@@ -192,7 +192,6 @@ function simulate_waveforms(stp_events::Table, detector::SolidStateDetectors.Sim
             stp_events,
             detector,
             max_nsteps = 20000,
-            # Δt = 1u"ns",
             Δt = simulator.time_step,
             diffusion = simulator.diffusion,
             self_repulsion = simulator.self_repulsion,

--- a/src/stp_to_pss.jl
+++ b/src/stp_to_pss.jl
@@ -15,11 +15,14 @@ The output is a table with simulated pulses, and a table with simulation truth
 function stp_to_pss(stp_table::Table, det_meta::PropDict, env::Environment, simulator::PSSimulator, noise_model::NoiseModel)
     @info "---------------------- stp -> pss (ideal pulses)"
 
-    # @info "//\\//\\//\\ Fano noise"
-    stp_table = fano_noise(stp_table, det_meta, env, noise_model)
-
     @info "_||_||_||_ Simulate detector" 
     sim = simulate_detector(det_meta, env, simulator; overwrite = false)
+
+    # @info "//\\//\\//\\ Fano noise"
+    # is this way because fano noise added using SSD even if siggen is used as Simulator 
+    # -> give det meta and env and build SSD sim inside
+    # -> confusing logs, rewrite!
+    stp_table = fano_noise(stp_table, det_meta, env, noise_model)
 
     @info "~.~.~.~.~ Simulate charge pulses"
     simulate_waveforms(stp_table, sim, simulator)

--- a/src/temp_utils.jl
+++ b/src/temp_utils.jl
@@ -102,7 +102,8 @@ Calculate final threshold based the value contained in <trigger>, and <preamp> g
 
 """
 function trigger_threshold(trigger::Trigger, preamp::GenericPreAmp, ::Union{NoiseFromSim, NoiseNone})
-    uconvert(u"eV", trigger.threshold_keV) / germanium_ionization_energy * preamp.gain
+    # uconvert(u"eV", trigger.threshold_keV) / germanium_ionization_energy * preamp.gain
+    uconvert(u"eV", trigger.threshold_keV) * preamp.gain # gain now in ADC/eV
     # threshold = trigger.threshold_keV == 0u"keV" ? noise_model.noise_σ * 3 : trigger.threshold_keV
     # uconvert(u"eV", threshold) / germanium_ionization_energy * preamp.gain
 end 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,10 +73,11 @@ end
     setup_settings = Dict(
         "preamp" => Dict(
             "type" => "generic",
-            "t_decay" => 50,
-            "t_rise" => 15,
-            "max_e" => 10000,
-            "offset" => 2000
+            "t_decay_in_us" => 50,
+            "t_rise_in_ns" => 100,
+            "gain_ADC_to_eV" => 0.138,
+            "offset_in_ADC" => 12000,
+            "noise_in_keV" => 2
         ),
         "fadc" => Dict(
             "type" => "generic",


### PR DESCRIPTION
-  small bug fixes in `baselines.jl`
- small bug fixes for fieldgen file caching in `detector.jl` and `legend_detector_to_siggen.jl`: no cached name provided = not caching simulation (for SSD or siggen); SSD works fine, but for siggen I had to create temporary configs in `cache/` folder with keyword `tmp`. The bug was that when a different simulation was launched, it read the "cached" tmp file anyway
- changed the "maximum energy" parameterization of preamp (where Emax is provided and set that `typemax(UInt16) = Emax`, and gain calculated based on that) to providing gain directly in units ADC/eV, and if then the ADC value goes over max of UInt16, it gets clamped. Changes in `preamp.jl`. Changes in other files because now gain is in ADC/eV and not ADC/charge. Will reconsider in the future what's more convenient, for now ADC/eV seems more convenient because can tune gain for example on the FEP peak
- option to provide noise in units of ADC rather than keV (changes in `preamp.jl` and `noise.jl`)
- option to provide offset in ADC rather than keV (in `preamp.jl`)
- Felix's bugfix to remove hits with no energy depositions in `pet_to_stp.jl`
- added option to provide a pre-generated pss table to `pss_to_raw()` (before could only provide the path to the saved pss hdf5 file, now also table in code)
- optional argument `n_waveforms` that allows to simulated a limited amount of waveforms to process from given file (in `stp_to_pss` and `pss_to_raw`), convenient for testing or tutorials