### PR TITLE
Delete cache of tutorial before deploying docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -59,6 +59,8 @@ makedocs(
     warnonly = ("nonstrict" in ARGS),
 )
 
+rm("tutorials/cache", recursive = true, force = true)
+
 deploydocs(
     repo = "github.com/legend-exp/LegendGeSim.jl.git",
     devbranch = "main",


### PR DESCRIPTION
Alternative to #55.
Don't avoid the cache, but delete the cache before deploying the documentation