### PR TITLE
Fix determination of `t0idx` in `trigger.jl`

### DIFF
--- a/src/trigger.jl
+++ b/src/trigger.jl
@@ -85,7 +85,7 @@ function simulate(wf::RDWaveform, trigger::TrapFilter)
     rdfilt!(online_filter_output, fi, signal)
     
     intersect::NamedTuple{(:x, :multiplicity), Tuple{T, Int64}} = Intersect{T}(0)(online_filter_output, T(trigger.threshold))
-    t0idx::Int = intersect.multiplicity > 0 ? ceil(Int, intersect.x) + fi.ngap + fi.navg2 - 1 : 0
+    t0idx::Int = intersect.multiplicity > 0 ? ceil(Int, intersect.x) + trigger_window_length - 1 : 0
     t0idx, maximum(online_filter_output)
     end
 end


### PR DESCRIPTION
This is the code I used to compose the following plots:
```julia
using LegendGeSim
using RadiationDetectorSignals
using RadiationDetectorDSP
using Plots

# Dummy waveform and TrapFilter to test
wf = RDWaveform(0:0.4:4000, max.(0, min.(1, 0.01 .* (-2000:0.4:2000))))
trigger = LegendGeSim.TrapFilter(window_lengths = (500,1000,500), threshold = 0.02)

let wf = wf, trigger = trigger
    T = Float32
    trigger_window_length = sum(trigger.window_lengths)
    let signal = T.(wf.signal)
        fi = fltinstance(TrapezoidalChargeFilter{T}(reverse(trigger.window_lengths)...), smplinfo(signal)) 
        online_filter_output = Vector{T}(undef, length(signal) - trigger_window_length + 1)
        rdfilt!(online_filter_output, fi, signal)
        plot(wf.signal, label = "Raw waveform")
        plot!(range(trigger_window_length, length = length(online_filter_output)), online_filter_output, label = "Filter output")
    end
end

t0idx, E = LegendGeSim.simulate(wf, trigger)
hline!([trigger.threshold], label = "Threshold value")
vline!([t0idx], label = "t0idx")
```

Before this PR:
![image](https://github.com/legend-exp/LegendGeSim.jl/assets/30291312/9f5c72e7-a8de-4134-9201-7a88a7d098a7)

After this PR:
![image](https://github.com/legend-exp/LegendGeSim.jl/assets/30291312/dca6b732-3577-4051-8822-32cc502a0bde)


Is this the behavior you envision? @sagitta42 
